### PR TITLE
Replace SCALING_FACTOR with dedicated scaling functions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,14 +135,9 @@ library <http://www.angusj.com/delphi/clipper.php>`__):
     solution = pc.Execute(pyclipper.CT_INTERSECTION, pyclipper.PFT_EVENODD, pyclipper.PFT_EVENODD) 
 
 The Clipper library uses integers instead of floating point values to
-preserve numerical robustness. You can use ``pyclipper.SCALING_FACTOR``
-to scale your values to preserve the desired presision. The default
-value is 1, which disables scaling. Scaling factor is also applied to the relevant
-parameters.
+preserve numerical robustness. You will need to scale coordinates using an appropriate factor, if you want to used fractional coordinates using the functions `scale_to_clipper()` and `scale_from_clipper()`.
 
-For more examples of use see ``tests/test_pyclipper.py`` and
-`Clipper
-documentation <http://www.angusj.com/delphi/clipper/documentation/Docs/_Body.htm>`__.
+For an explanation, see https://github.com/greginvm/pyclipper/wiki/Deprecating-SCALING_FACTOR.
 
 Authors
 =======

--- a/pyclipper/pyclipper.pyx
+++ b/pyclipper/pyclipper.pyx
@@ -351,7 +351,7 @@ def CleanPolygon(poly, double distance=1.415):
     cleaned polygon
     """
     cdef Path out_poly
-    c_CleanPolygon(_to_clipper_path(poly), out_poly, _to_clipper_double(distance))
+    c_CleanPolygon(_to_clipper_path(poly), out_poly, distance)
     return _from_clipper_path(out_poly)
 
 
@@ -367,7 +367,7 @@ def CleanPolygons(polys, double distance=1.415):
     list of cleaned polygons
     """
     cdef Paths out_polys = _to_clipper_paths(polys)
-    c_CleanPolygons(out_polys, _to_clipper_double(distance))
+    c_CleanPolygons(out_polys, distance)
     return _from_clipper_paths(out_polys)
 
 
@@ -591,8 +591,8 @@ cdef class Pyclipper:
         _check_scaling_factor()
         
         cdef IntRect rr = <IntRect> self.thisptr.GetBounds()
-        return PyIntRect(left=_from_clipper_value(rr.left), top=_from_clipper_value(rr.top),
-                         right=_from_clipper_value(rr.right), bottom=_from_clipper_value(rr.bottom))
+        return PyIntRect(left=rr.left, top=rr.top,
+                         right=rr.right, bottom=rr.bottom)
 
     def Execute(self, ClipType clip_type,
                 PolyFillType subj_fill_type=pftEvenOdd, PolyFillType clip_fill_type=pftEvenOdd):
@@ -728,7 +728,7 @@ cdef class PyclipperOffset:
         list of offset paths
         """
         cdef Paths c_solution
-        self.thisptr.Execute(c_solution, _to_clipper_double(delta))
+        self.thisptr.Execute(c_solution, delta)
         return _from_clipper_paths(c_solution)
 
     def Execute2(self, double delta):
@@ -743,7 +743,7 @@ cdef class PyclipperOffset:
         PyPolyNode
         """
         cdef PolyTree solution
-        self.thisptr.Execute(solution, _to_clipper_double(delta))
+        self.thisptr.Execute(solution, delta)
         return _from_poly_tree(solution)
 
     def Clear(self):
@@ -774,12 +774,12 @@ cdef class PyclipperOffset:
         def __get__(self):
             _check_scaling_factor()
             
-            return _from_clipper_value(<double> self.thisptr.ArcTolerance)
+            return self.thisptr.ArcTolerance
 
         def __set__(self, value):
             _check_scaling_factor()
             
-            self.thisptr.ArcTolerance = _to_clipper_double(<double> value)
+            self.thisptr.ArcTolerance = value
 
 
 cdef _filter_polynode(pypolynode, result, filter_func=None):
@@ -848,7 +848,7 @@ cdef Path _to_clipper_path(object polygon):
 
 
 cdef IntPoint _to_clipper_point(object py_point):
-    return IntPoint(_to_clipper_int(py_point[0]), _to_clipper_int(py_point[1]))
+    return IntPoint(py_point[0], py_point[1])
 
 
 cdef object _from_clipper_paths(Paths paths):
@@ -870,10 +870,7 @@ cdef object _from_clipper_path(Path path):
     cdef IntPoint point
     for i in xrange(path.size()):
         point = path[i]
-        poly.append([
-            _from_clipper_value(point.X),
-            _from_clipper_value(point.Y)
-        ])
+        poly.append([point.X, point.Y])
     return poly
 
 
@@ -884,15 +881,3 @@ def _check_scaling_factor():
     
     if SCALING_FACTOR != 1:
         _warnings.warn('SCALING_FACTOR is deprecated and it\'s value is ignored. See https://github.com/greginvm/pyclipper/wiki/Deprecating-SCALING_FACTOR for more information.', DeprecationWarning)
-
-
-cdef cInt _to_clipper_int(val):
-    return val * SCALING_FACTOR
-
-
-cdef double _to_clipper_double(val):
-    return val * <double>SCALING_FACTOR
-
-
-cdef double _from_clipper_value(val):
-    return val / <double>SCALING_FACTOR

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = []
+        self.pytest_args = ['tests']
 
     def finalize_options(self):
         TestCommand.finalize_options(self)

--- a/tests/test_pyclipper.py
+++ b/tests/test_pyclipper.py
@@ -266,6 +266,21 @@ class TestPyclipperExecute(TestCase):
 
         self.assertTrue(_do_solutions_match(manualy_scaled, scaled_solution, test_factor))
 
+    def test_exact_results(self):
+        """
+        Test whether coordinates passed into the library are returned exactly, if they are not affected by the operation.
+        """
+        
+        pc = pyclipper.Pyclipper()
+        
+        # Some large triangle.
+        path = [[[0, 1], [0, 0], [15 ** 15, 0]]]
+
+        pc.AddPaths(path, pyclipper.PT_SUBJECT, True)
+        result = pc.Execute(pyclipper.PT_CLIP, pyclipper.PFT_EVENODD, pyclipper.PFT_EVENODD)
+        
+        assert result == path
+
     def check_pypolynode(self, node):
         self.assertTrue(len(node.Contour) is 0 or len(node.Contour) > 2)
 

--- a/tests/test_pyclipper.py
+++ b/tests/test_pyclipper.py
@@ -243,29 +243,6 @@ class TestPyclipperExecute(TestCase):
         solution = self.pc.Execute(*self.default_args)
         self.assertEqual(len(solution), 0)
 
-    def test_scaling(self):
-        test_factor = 10000
-        test_clip = _modify_vertices(PATH_CLIP_1, addend=0.23591)
-        test_subj_1 = _modify_vertices(PATH_SUBJ_1, addend=0.28591)
-        test_subj_2 = _modify_vertices(PATH_SUBJ_2, addend=0.52391)
-
-        pyclipper.SCALING_FACTOR = test_factor
-        pc = pyclipper.Pyclipper()
-        self.add_paths(pc, test_clip, [test_subj_1, test_subj_2])
-        scaled_solution = pc.Execute(*self.default_args)
-
-        pyclipper.SCALING_FACTOR = 1
-        pc = pyclipper.Pyclipper()
-        self.add_paths(pc, test_clip, [test_subj_1, test_subj_2], multiplier=test_factor)
-        manualy_scaled = pc.Execute(*self.default_args)
-
-        self.assertEqual(len(scaled_solution), len(manualy_scaled))
-
-        manualy_scaled[0] = _modify_vertices(manualy_scaled[0], multiplier=1.0 / test_factor)
-        manualy_scaled[1] = _modify_vertices(manualy_scaled[1], multiplier=1.0 / test_factor)
-
-        self.assertTrue(_do_solutions_match(manualy_scaled, scaled_solution, test_factor))
-
     def test_exact_results(self):
         """
         Test whether coordinates passed into the library are returned exactly, if they are not affected by the operation.
@@ -301,28 +278,6 @@ class TestPyclipperOffset(TestCase):
     def add_path(pc, path):
         pc.AddPath(path, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
 
-    def test_path_scaling(self):
-        test_factor = 10000
-        test_path = _modify_vertices(PATH_CLIP_1, addend=0.23591)
-        # paths and solution scaled by Pyclipper
-        pyclipper.SCALING_FACTOR = test_factor
-        pc = pyclipper.PyclipperOffset(miter_limit=2.0, arc_tolerance=0.25)
-        self.add_path(pc, test_path)
-        scaled_solution = pc.Execute(2.2)
-
-        # manualy scaled
-        pyclipper.SCALING_FACTOR = 1
-        pc = pyclipper.PyclipperOffset(miter_limit=2.0, arc_tolerance=0.25 * test_factor)
-        self.add_path(pc, _modify_vertices(test_path, multiplier=test_factor))
-        control_solution = pc.Execute(2.2 * test_factor)
-
-        self.assertEqual(len(scaled_solution), len(control_solution))
-        self.assertEqual(len(scaled_solution), 1)
-
-        control_solution = [_modify_vertices(control_solution[0], multiplier=1.0 / test_factor)]
-
-        self.assertTrue(_do_solutions_match(control_solution, scaled_solution, test_factor))
-
     def test_execute(self):
         pc = pyclipper.PyclipperOffset()
         self.add_path(pc, PATH_CLIP_1)
@@ -345,6 +300,44 @@ class TestPyclipperOffset(TestCase):
         solution = pc.Execute(2.0)
         self.assertIsInstance(solution, list)
         self.assertEqual(len(solution), 0)
+
+
+class TestScalingFactorWarning(TestCase):
+    def setUp(self):
+        pyclipper.SCALING_FACTOR = 2.
+        self.pc = pyclipper.Pyclipper()
+    
+    def test_orientation(self):
+        with self.assertWarns(DeprecationWarning):
+            pyclipper.Orientation(PATH_SUBJ_1)
+
+    def test_area(self):
+        with self.assertWarns(DeprecationWarning):
+            pyclipper.Area(PATH_SUBJ_1)
+	 
+    def test_point_in_polygon(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(pyclipper.PointInPolygon((180, 200), PATH_SUBJ_1), -1)
+	 
+    def test_minkowski_sum(self):
+        with self.assertWarns(DeprecationWarning):
+            pyclipper.MinkowskiSum(PATTERN, PATH_SIGMA, False)
+	 
+    def test_minkowski_sum2(self):
+        with self.assertWarns(DeprecationWarning):
+            pyclipper.MinkowskiSum2(PATTERN, [PATH_SIGMA], False)
+	 
+    def test_minkowski_diff(self):
+        with self.assertWarns(DeprecationWarning):
+            pyclipper.MinkowskiDiff(PATH_SUBJ_1, PATH_SUBJ_2)
+	 
+    def test_add_path(self):
+        with self.assertWarns(DeprecationWarning):
+            self.pc.AddPath(PATH_CLIP_1, poly_type=pyclipper.PT_CLIP)
+
+    def test_add_paths(self):
+        with self.assertWarns(DeprecationWarning):
+            self.pc.AddPaths([PATH_SUBJ_1, PATH_SUBJ_2], poly_type=pyclipper.PT_SUBJECT)
 
 
 def _do_solutions_match(paths_1, paths_2, factor=None):

--- a/tests/test_pyclipper.py
+++ b/tests/test_pyclipper.py
@@ -340,6 +340,57 @@ class TestScalingFactorWarning(TestCase):
             self.pc.AddPaths([PATH_SUBJ_1, PATH_SUBJ_2], poly_type=pyclipper.PT_SUBJECT)
 
 
+class TestScalingFunctions(TestCase):
+    scale = 2 ** 31
+    path = [(0, 0), (1, 1)]
+    paths = [path] * 3
+    
+    def test_value_scale_to(self):
+        value = 0.5
+        res = pyclipper.scale_to_clipper(value, self.scale)
+        
+        assert isinstance(res, int)
+        assert res == int(value * self.scale)
+    
+    def test_value_scale_from(self):
+        value = 1000000000000
+        res = pyclipper.scale_from_clipper(value, self.scale)
+        
+        assert isinstance(res, float)
+        # Convert to float to get "normal" division in Python < 3.
+        assert res == float(value) / self.scale
+    
+    def test_path_scale_to(self):
+        res = pyclipper.scale_to_clipper(self.path)
+        
+        assert len(res) == len(self.path)
+        assert all(isinstance(i, list) for i in res)
+        assert all(isinstance(j, int) for i in res for j in i)
+    
+    def test_path_scale_from(self):
+        res = pyclipper.scale_from_clipper(self.path)
+        
+        assert len(res) == len(self.path)
+        assert all(isinstance(i, list) for i in res)
+        assert all(isinstance(j, float) for i in res for j in i)
+    
+    def test_paths_scale_to(self):
+        res = pyclipper.scale_to_clipper(self.paths)
+        
+        assert len(res) == len(self.paths)
+        assert all(isinstance(i, list) for i in res)
+        assert all(isinstance(j, list) for i in res for j in i)
+        assert all(isinstance(k, int) for i in res for j in i for k in j)
+    
+    def test_paths_scale_from(self):
+        res = pyclipper.scale_from_clipper(self.paths)
+        
+        assert len(res) == len(self.paths)
+        assert all(isinstance(i, list) for i in res)
+        assert all(isinstance(j, list) for i in res for j in i)
+        assert all(isinstance(k, float) for i in res for j in i for k in j)
+
+
 def _do_solutions_match(paths_1, paths_2, factor=None):
     if len(paths_1) != len(paths_2):
         return False


### PR DESCRIPTION
This replaced `SCALING_FACTOR` with dedicated methods to scale coordinates from and to an `int`-based representation suitable for Clipper. See https://github.com/greginvm/pyclipper/wiki/Deprecating-SCALING_FACTOR.

All methods which previously used `SCALING_FACTOR` should now raise a warning when `SCALING_FACTOR` has been set to a value different from the initial value of `1`.