### PR TITLE
set up CI to run tests and build wheels for osx, manylinux1 and windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,3 +82,15 @@ after_test:
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report
   - path: wheelhouse\*.whl
+
+deploy:
+  # Deploy wheels on tags to GitHub Releases
+  # See http://www.appveyor.com/docs/deployment/github
+  - provider: GitHub
+    auth_token:
+      secure: NDuEsX2sqAbFegVqSkL45mJyfzirm14zt4EHSmErI0AbJvZQftFaarVqar0WAfiL
+    draft: false
+    prerelease: false
+    on:
+      # branch: master
+      appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,10 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3"
+      PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"
@@ -20,6 +24,10 @@ environment:
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python34-x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,84 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\.appveyor\\run_with_env.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+
+  # Prepend newly installed Python to the PATH
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Upgrade pip to avoid out-of-date warnings
+  - "python -m pip install --disable-pip-version-check --upgrade pip"
+  - "pip --version"
+
+  # Upgrade setuptools, wheel and virtualenv
+  - "pip install --upgrade setuptools wheel virtualenv"
+
+  # Create new virtual environment and activate it
+  - "python -m virtualenv venv"
+  - "venv\\Scripts\\activate"
+  - "python -c \"import sys; print(sys.executable)\""
+
+  # Install build and test dependencies
+  - "%CMD_IN_ENV% pip install cython sympy unittest2 pytest"
+
+# We skip the build step as the `built_ext`  command is implicitly called
+# when running `python setup.py test`
+build: off
+
+test_script:
+  # Run the project tests
+  - "%CMD_IN_ENV% python setup.py test --pytest-args=\"-v tests\""
+
+after_test:
+  # If tests are successful, create binary packages
+  - "%CMD_IN_ENV% pip wheel -w wheelhouse ."
+  - ps: "ls wheelhouse"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report
+  - path: wheelhouse\*.whl

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,14 +83,20 @@ artifacts:
   # Archive the generated packages in the ci.appveyor.com build report
   - path: wheelhouse\*.whl
 
-deploy:
-  # Deploy wheels on tags to GitHub Releases
-  # See http://www.appveyor.com/docs/deployment/github
-  - provider: GitHub
-    auth_token:
-      secure: NDuEsX2sqAbFegVqSkL45mJyfzirm14zt4EHSmErI0AbJvZQftFaarVqar0WAfiL
-    draft: false
-    prerelease: false
-    on:
-      # branch: master
-      appveyor_repo_tag: true
+#### Please replace the secure 'auth_token' below with your own.
+#### First, you need to generate a Github Personal API access token at
+#### https://github.com/settings/tokens, selecting scope 'public_repo'.
+#### Then, you encrypt it using https://ci.appveyor.com/tools/encrypt
+#### and paste it below.
+#### More info at: https://www.appveyor.com/docs/deployment/github/
+#
+# deploy:
+#   # Deploy wheels on tags to GitHub Releases
+#   - provider: GitHub
+#     auth_token:
+#       secure: NDuEsX2sqAbFegVqSkL45mJyfzirm14zt4EHSmErI0AbJvZQftFaarVqar0WAfiL
+#     draft: false
+#     prerelease: false
+#     on:
+#       branch: master
+#       appveyor_repo_tag: true

--- a/.appveyor/run_with_env.cmd
+++ b/.appveyor/run_with_env.cmd
@@ -1,0 +1,88 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON_VERSION:~0,1%
+IF "%PYTHON_VERSION:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
+) ELSE (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,2%
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "multibuild"]
+	path = multibuild
+	url = https://github.com/matthew-brett/multibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,13 @@ matrix:
         - UNICODE_WIDTH=16
     - os: linux
       env:
+        - MB_PYTHON_VERSION=3.3
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.3
+        - PLAT=i686
+    - os: linux
+      env:
         - MB_PYTHON_VERSION=3.4
     - os: linux
       env:
@@ -56,6 +63,10 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=2.7
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.3
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
+        - BUILD_SDIST=true
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
@@ -74,3 +75,18 @@ install:
 
 script:
   - install_run $PLAT
+
+after_success:
+  # if tagged, create the source distribution for the deploy stage
+  - if [ -n "$TRAVIS_TAG" ] && [ "$BUILD_SDIST" == true ]; then pip install cython; python setup.py sdist -d ${TRAVIS_BUILD_DIR}/wheelhouse; fi
+
+deploy:
+  provider: releases
+  api_key:
+    secure: smeR8YNNcSTTf4LPts6yR2HItgAsld65P52lGVjPvCxe7lx5unXrC8sPMKK8EQcHEruxVbY204z7MKyKcAMg/DCe1r+bYGuH0oT+lRLxJQPNNoo7innFax58f7pfutbDN54DLQ/s9aPE2Ogk1CcH5pGzLtJziPF/oGW97wBtOmUQcFFcWBjw6/qs2jS0SkZ1jiHLH1/Vn6Rquy4EWthOTR9KLpdqPtQAkFr5dVtsjV93YLX1bUFbEL6BDSu6gTAfQFRby7D991Uv6+xH5bcECwPwSibnZIPV0HyuYpGOp053YKKtovl2IO09rNtB56BLZsKOOoCWS8/sxI0z4uKwRFg+nYblaRUuwJ0IM6IupUciXdvDRWYYoZcbNRVFhoO9Ct6/wsusI4tcbSiGdT0aPI3zLPbtAwvuCRVazTx5VuiM3JZQIir+3Qpv4TzXAw0Cn/eOIgT6EP+I/FRuHYIzEICypx9vWqjAJTcJ69I5OqmIUPuVrLXWOO51G3qfHpMfhn9TGhbc63v8SX6V4bovVrmxwLzGnr+VA9grnytdoeEeaZZ+SEsOrOoEI2BbnXLDeWZNbC1X1IRiD9LxARFrwbXWgLPlk1nZU49pbkuuPKrccvgv2jc0v5GLgfDQyMINO/06FIMpMbzxI/skTv6DXzRz/jwM+LSZjxRRR9Gb0nk=
+  file_glob: true
+  file: "${TRAVIS_BUILD_DIR}/wheelhouse/*"
+  skip_cleanup: true
+  on:
+    repo: anthrotype/pyclipper
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,13 +80,17 @@ after_success:
   # if tagged, create the source distribution for the deploy stage
   - if [ -n "$TRAVIS_TAG" ] && [ "$BUILD_SDIST" == true ]; then pip install cython; python setup.py sdist -d ${TRAVIS_BUILD_DIR}/wheelhouse; fi
 
-deploy:
-  provider: releases
-  api_key:
-    secure: smeR8YNNcSTTf4LPts6yR2HItgAsld65P52lGVjPvCxe7lx5unXrC8sPMKK8EQcHEruxVbY204z7MKyKcAMg/DCe1r+bYGuH0oT+lRLxJQPNNoo7innFax58f7pfutbDN54DLQ/s9aPE2Ogk1CcH5pGzLtJziPF/oGW97wBtOmUQcFFcWBjw6/qs2jS0SkZ1jiHLH1/Vn6Rquy4EWthOTR9KLpdqPtQAkFr5dVtsjV93YLX1bUFbEL6BDSu6gTAfQFRby7D991Uv6+xH5bcECwPwSibnZIPV0HyuYpGOp053YKKtovl2IO09rNtB56BLZsKOOoCWS8/sxI0z4uKwRFg+nYblaRUuwJ0IM6IupUciXdvDRWYYoZcbNRVFhoO9Ct6/wsusI4tcbSiGdT0aPI3zLPbtAwvuCRVazTx5VuiM3JZQIir+3Qpv4TzXAw0Cn/eOIgT6EP+I/FRuHYIzEICypx9vWqjAJTcJ69I5OqmIUPuVrLXWOO51G3qfHpMfhn9TGhbc63v8SX6V4bovVrmxwLzGnr+VA9grnytdoeEeaZZ+SEsOrOoEI2BbnXLDeWZNbC1X1IRiD9LxARFrwbXWgLPlk1nZU49pbkuuPKrccvgv2jc0v5GLgfDQyMINO/06FIMpMbzxI/skTv6DXzRz/jwM+LSZjxRRR9Gb0nk=
-  file_glob: true
-  file: "${TRAVIS_BUILD_DIR}/wheelhouse/*"
-  skip_cleanup: true
-  on:
-    repo: anthrotype/pyclipper
-    tags: true
+####  The following section enables automatic deployment on tags to GitHub Releases.
+####  You must replace the secure api_key with yours, as created by `travis setup releases`.
+####  See https://docs.travis-ci.com/user/deployment/releases
+#
+# deploy:
+#   provider: releases
+#   api_key:
+#     secure: smeR8YNNcSTTf4LPts6yR2HItgAsld65P52lGVjPvCxe7lx5unXrC8sPMKK8EQcHEruxVbY204z7MKyKcAMg/DCe1r+bYGuH0oT+lRLxJQPNNoo7innFax58f7pfutbDN54DLQ/s9aPE2Ogk1CcH5pGzLtJziPF/oGW97wBtOmUQcFFcWBjw6/qs2jS0SkZ1jiHLH1/Vn6Rquy4EWthOTR9KLpdqPtQAkFr5dVtsjV93YLX1bUFbEL6BDSu6gTAfQFRby7D991Uv6+xH5bcECwPwSibnZIPV0HyuYpGOp053YKKtovl2IO09rNtB56BLZsKOOoCWS8/sxI0z4uKwRFg+nYblaRUuwJ0IM6IupUciXdvDRWYYoZcbNRVFhoO9Ct6/wsusI4tcbSiGdT0aPI3zLPbtAwvuCRVazTx5VuiM3JZQIir+3Qpv4TzXAw0Cn/eOIgT6EP+I/FRuHYIzEICypx9vWqjAJTcJ69I5OqmIUPuVrLXWOO51G3qfHpMfhn9TGhbc63v8SX6V4bovVrmxwLzGnr+VA9grnytdoeEeaZZ+SEsOrOoEI2BbnXLDeWZNbC1X1IRiD9LxARFrwbXWgLPlk1nZU49pbkuuPKrccvgv2jc0v5GLgfDQyMINO/06FIMpMbzxI/skTv6DXzRz/jwM+LSZjxRRR9Gb0nk=
+#   file_glob: true
+#   file: "${TRAVIS_BUILD_DIR}/wheelhouse/*"
+#   skip_cleanup: true
+#   on:
+#     repo: greginvm/pyclipper
+#     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,76 @@
+env:
+  global:
+    # directory containing the project source
+    - REPO_DIR=.
+    # pip dependencies to _build_ project
+    - BUILD_DEPENDS="Cython"
+    # pip dependencies to _test_ project
+    - TEST_DEPENDS="sympy unittest2 pytest"
+    - PLAT=x86_64
+    - UNICODE_WIDTH=32
+
+language: python
+# The travis Python version is unrelated to the version we build and test
+# with.  This is set with the MB_PYTHON_VERSION variable.
+python: 3.5
+sudo: required
+dist: trusty
+services: docker
+
+matrix:
+  exclude:
+    # Exclude the default Python 3.5 build
+    - python: 3.5
+  include:
+    - os: linux
+      env: MB_PYTHON_VERSION=2.7
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - UNICODE_WIDTH=16
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - PLAT=i686
+        - UNICODE_WIDTH=16
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.4
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.4
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.5
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.5
+        - PLAT=i686
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=2.7
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.4
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.5
+
+before_install:
+  - source multibuild/common_utils.sh
+  - source multibuild/travis_steps.sh
+  - before_install
+
+install:
+  - build_wheel $REPO_DIR $PLAT
+
+script:
+  - install_run $PLAT

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,16 @@
+# Define custom utilities
+# Test for OSX with [ -n "$IS_OSX" ]
+
+function pre_build {
+    # Any stuff that you need to do before you start building the wheels
+    # Runs in the root directory of this repository.
+    :
+}
+
+function run_tests {
+    # check we have the expected version and architecture for Python
+    python -c "import sys; print(sys.version)"
+    python -c "import struct; print(struct.calcsize('P') * 8)"
+    # run the test suite
+    py.test -v ../tests
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.rst
+
+[sdist]
+formats = zip

--- a/tests/test_pyclipper.py
+++ b/tests/test_pyclipper.py
@@ -5,6 +5,12 @@ Tests for Pyclipper wrapper library.
 
 from __future__ import print_function
 from unittest2 import TestCase, main
+import sys
+
+if sys.version_info < (3,):
+    integer_types = (int, long)
+else:
+    integer_types = (int,)
 
 import pyclipper
 
@@ -350,7 +356,7 @@ class TestScalingFunctions(TestCase):
         value = 0.5
         res = pyclipper.scale_to_clipper(value, self.scale)
 
-        assert isinstance(res, int)
+        assert isinstance(res, integer_types)
         assert res == int(value * self.scale)
 
     def test_value_scale_from(self):
@@ -366,7 +372,7 @@ class TestScalingFunctions(TestCase):
 
         assert len(res) == len(self.path)
         assert all(isinstance(i, list) for i in res)
-        assert all(isinstance(j, int) for i in res for j in i)
+        assert all(isinstance(j, integer_types) for i in res for j in i)
 
     def test_path_scale_from(self):
         res = pyclipper.scale_from_clipper(self.path)
@@ -381,7 +387,7 @@ class TestScalingFunctions(TestCase):
         assert len(res) == len(self.paths)
         assert all(isinstance(i, list) for i in res)
         assert all(isinstance(j, list) for i in res for j in i)
-        assert all(isinstance(k, int) for i in res for j in i for k in j)
+        assert all(isinstance(k, integer_types) for i in res for j in i for k in j)
 
     def test_paths_scale_from(self):
         res = pyclipper.scale_from_clipper(self.paths)


### PR DESCRIPTION
Hello,

I'm using the excellent https://github.com/matthew-brett/multibuild, a set of shell scripts used to build OSX and Linux wheels for the Python scientific stack.
This makes super easy to set up Travis as a Python wheel build farm. (Thanks @matthew-brett!)

I also tried Travis automatic deployment to Github Releases; you can see it working from my fork: https://github.com/anthrotype/pyclipper/releases

@greginvm may want to replace my Github secure `aut_key` with his own, by running the `travis setup releases` command as explained in https://docs.travis-ci.com/user/deployment/releases

BTW, Travis also offers automatic deployment to PyPI, but the latter seems to force you rebuilding the wheel with a regular `bdist_wheel` command running outside our Docker `manylinux1` image. I'm trying to understand if it's possible to upload precompiled artifacts to PyPI using Travis (see https://github.com/travis-ci/dpl/issues/496).

In the meantime, I think it's okay if @greginvm manually uploads to PyPI the wheels, by downloading them from the Github releases once Travis has finished uploading them.

This is only the first part. Tomorrow I'll work on adding Windows support via Appveyor -- which also offers automatic deployment to Github releases.

Let me know if you have questions or comments.
Thank you!

Cosimo