### PR TITLE
use setuptools_scm to generate package version and sdist files list

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,7 +72,7 @@ install:
   - "python -c \"import sys; print(sys.executable)\""
 
   # Install build and test dependencies
-  - "%CMD_IN_ENV% pip install cython sympy"
+  - "%CMD_IN_ENV% pip install cython sympy unittest2 pytest"
 
 # We skip the build step as the `built_ext`  command is implicitly called
 # when running `python setup.py test`

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,7 +72,7 @@ install:
   - "python -c \"import sys; print(sys.executable)\""
 
   # Install build and test dependencies
-  - "%CMD_IN_ENV% pip install cython sympy unittest2 pytest"
+  - "%CMD_IN_ENV% pip install cython sympy"
 
 # We skip the build step as the `built_ext`  command is implicitly called
 # when running `python setup.py test`
@@ -80,7 +80,7 @@ build: off
 
 test_script:
   # Run the project tests
-  - "%CMD_IN_ENV% python setup.py test --pytest-args=\"-v tests\""
+  - "%CMD_IN_ENV% python setup.py test"
 
 after_test:
   # If tests are successful, create binary packages

--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pyclipper.egg-info
 pyclipper/pyclipper.cpp
 *.pyc
 MANIFEST
+.eggs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ env:
     - PLAT=x86_64
     - UNICODE_WIDTH=32
 
+# Travis only clones the latest 50 commits. We need the full repository to
+# compute the version string from the git metadata:
+# https://github.com/travis-ci/travis-ci/issues/3412#issuecomment-83993903
+# https://github.com/pypa/setuptools_scm/issues/93
+git:
+  depth: 9999999
+
 language: python
 # The travis Python version is unrelated to the version we build and test
 # with.  This is set with the MB_PYTHON_VERSION variable.

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
     # directory containing the project source
     - REPO_DIR=.
     # pip dependencies to _build_ project
-    - BUILD_DEPENDS="Cython"
+    - BUILD_DEPENDS="Cython setuptools>=25"
     # pip dependencies to _test_ project
     - TEST_DEPENDS="sympy unittest2 pytest"
     - PLAT=x86_64

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+# By default setuptools_scm will include in the source distribution all the
+# files under version control, as resulting from `git ls-files`.
+
+# Here we only need to include those which are not tracked by git but we do
+# want to be included
+include pyclipper/pyclipper.cpp
+
+# and exclude those that are tracked by git but don't want to be in the sdist
+exclude dev
+exclude .git*
+exclude .appveyor.yml .travis.yml
+exclude .appveyor/*
+exclude multibuild/*
+exclude config.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include pyclipper/clipper.hpp
-include pyclipper/clipper.cpp
-include pyclipper/pyclipper.cpp
-include pyclipper/extra_defines.hpp

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,14 @@ description-file = README.rst
 
 [sdist]
 formats = zip
+
+[aliases]
+test = pytest
+
+[tool:pytest]
+testpaths = tests
+addopts =
+    # run py.test in verbose mode
+    -v
+    # show extra test summary info
+    -r a

--- a/setup.py
+++ b/setup.py
@@ -72,10 +72,6 @@ if sys.argv[-1] == 'publish':
     os.system("python setup.py bdist_wheel upload")
     sys.exit()
 
-if sys.argv[-1] == 'tag':
-    os.system("git tag -a %s -m 'version %s'" % (version, version))
-    os.system("git push --tags")
-    sys.exit()
 
 setup(
     name='pyclipper',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import sys
 import os
 from setuptools import setup
 from setuptools.extension import Extension
-from setuptools.command.test import test as TestCommand
 
 """
 Note on using the setup.py:
@@ -44,6 +43,10 @@ else:
     cmdclass = {}
 
 
+needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
+pytest_runner = ['pytest_runner'] if needs_pytest else []
+
+
 ext = Extension("pyclipper",
                 sources=sources,
                 language="c++",
@@ -53,31 +56,6 @@ ext = Extension("pyclipper",
                 # See pyclipper/clipper.hpp
                 define_macros=[('use_lines', 1)]
                 )
-
-
-# This command has been borrowed from
-# http://pytest.org/latest/goodpractises.html
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = ['tests']
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
-cmdclass['test'] = PyTest
 
 
 # This command has been borrowed from
@@ -116,7 +94,7 @@ setup(
     setup_requires=[
        'setuptools_scm>=1.11.1',
        'setuptools_scm_git_archive>=1.0',
-    ],
+    ] + pytest_runner,
     tests_require=['unittest2', 'pytest'],
     cmdclass=cmdclass,
 )

--- a/setup.py
+++ b/setup.py
@@ -58,14 +58,6 @@ ext = Extension("pyclipper",
                 )
 
 
-# This command has been borrowed from
-# http://www.pydanny.com/python-dot-py-tricks.html
-if sys.argv[-1] == 'publish':
-    os.system("python setup.py sdist upload")
-    os.system("python setup.py bdist_wheel upload")
-    sys.exit()
-
-
 setup(
     name='pyclipper',
     use_scm_version=True,

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ from setuptools import setup
 from setuptools.extension import Extension
 from setuptools.command.test import test as TestCommand
 
-version = '1.0.3'
-
 """
 Note on using the setup.py:
 setup.py operates in 2 modes that are based on the presence of the 'dev' file in the root of the project.
@@ -81,7 +79,7 @@ if sys.argv[-1] == 'tag':
 
 setup(
     name='pyclipper',
-    version=version,
+    use_scm_version=True,
     description='Cython wrapper for the C++ translation of the Angus Johnson\'s Clipper library (ver. 6.2.1)',
     author='Angus Johnson, Maxime Chalton, Lukas Treyer, Gregor Ratajc',
     author_email='me@gregorratajc.com',
@@ -104,6 +102,10 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules"
     ],
     ext_modules=[ext],
+    setup_requires=[
+       'setuptools_scm>=1.11.1',
+       'setuptools_scm_git_archive>=1.0',
+    ],
     tests_require=['unittest2', 'pytest'],
     cmdclass={
         'test': PyTest,


### PR DESCRIPTION
setuptools_scm is a setuptools plugin that uses git metadata to manage python package versions

https://github.com/pypa/setuptools_scm

It also replaces the use of MANIFEST.in, by including in the source distribution all the
files that are under version control (using `git ls-files`).

An extra plugin 'setuptools_scm_git_archive' also adds support for git archives,
e.g the .zip files automatically generated on Github.

https://github.com/Changaco/setuptools_scm_git_archive

For example, one could do: `pip install https://github.com/greginvm/pyclipper/archive/1.0.4.zip`

Note that installing from git archives currently works only for tagged commits, because
of limitations of git archive format itself.

However, for non-tagged commits one can still install from the git repo:
`pip install git+https://github.com/greginvm/pyclipper`