### PR TITLE
Set up Travis/Appveyor for Python 3.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,10 +10,6 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"
@@ -28,10 +24,6 @@ environment:
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python34-x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,10 @@ environment:
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
@@ -36,6 +40,10 @@ environment:
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
 
 init:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,13 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=i686
     - os: osx
       language: generic
       env:
@@ -82,6 +89,10 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.6
 
 before_install:
   - source multibuild/common_utils.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,6 @@ matrix:
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=3.3
-    - os: osx
-      language: generic
-      env:
         - MB_PYTHON_VERSION=3.4
     - os: osx
       language: generic


### PR DESCRIPTION
This is so we can build wheels for python 3.6 on Linux, macOS and Windows.