### PR TITLE
Use Clipper 6.4.2

### DIFF
--- a/pyclipper/clipper.hpp
+++ b/pyclipper/clipper.hpp
@@ -1,10 +1,10 @@
 /*******************************************************************************
 *                                                                              *
 * Author    :  Angus Johnson                                                   *
-* Version   :  6.2.1                                                           *
-* Date      :  31 October 2014                                                 *
+* Version   :  6.4.2                                                           *
+* Date      :  27 February 2017                                                *
 * Website   :  http://www.angusj.com                                           *
-* Copyright :  Angus Johnson 2010-2014                                         *
+* Copyright :  Angus Johnson 2010-2017                                         *
 *                                                                              *
 * License:                                                                     *
 * Use, modification & distribution is subject to Boost Software License Ver 1. *
@@ -34,7 +34,7 @@
 #ifndef clipper_hpp
 #define clipper_hpp
 
-#define CLIPPER_VERSION "6.2.0"
+#define CLIPPER_VERSION "6.4.2"
 
 //use_int32: When enabled 32bit ints are used instead of 64bit ints. This
 //improve performance but coordinate values are limited to the range +/- 46340
@@ -44,12 +44,13 @@
 //#define use_xyz
 
 //use_lines: Enables line clipping. Adds a very minor cost to performance.
-//#define use_lines
+#define use_lines
   
 //use_deprecated: Enables temporary support for the obsolete functions
 //#define use_deprecated  
 
 #include <vector>
+#include <list>
 #include <set>
 #include <stdexcept>
 #include <cstring>
@@ -145,6 +146,7 @@ public:
     bool IsOpen() const;
     int ChildCount() const;
 private:
+    //PolyNode& operator =(PolyNode& other); 
     unsigned Index; //node index in Parent.Childs
     bool m_IsOpen;
     JoinType m_jointype;
@@ -158,12 +160,13 @@ private:
 class PolyTree: public PolyNode
 { 
 public:
-    ~PolyTree(){Clear();};
+    ~PolyTree(){ Clear(); };
     PolyNode* GetFirst() const;
     void Clear();
     int Total() const;
 private:
-    PolyNodes AllNodes;
+  //PolyTree& operator =(PolyTree& other);
+  PolyNodes AllNodes;
     friend class Clipper; //to access AllNodes
 };
 
@@ -200,7 +203,6 @@ enum EdgeSide { esLeft = 1, esRight = 2};
 struct TEdge;
 struct IntersectNode;
 struct LocalMinimum;
-struct Scanbeam;
 struct OutPt;
 struct OutRec;
 struct Join;
@@ -220,7 +222,7 @@ class ClipperBase
 public:
   ClipperBase();
   virtual ~ClipperBase();
-  bool AddPath(const Path &pg, PolyType PolyTyp, bool Closed);
+  virtual bool AddPath(const Path &pg, PolyType PolyTyp, bool Closed);
   bool AddPaths(const Paths &ppg, PolyType PolyTyp, bool Closed);
   virtual void Clear();
   IntRect GetBounds();
@@ -229,12 +231,18 @@ public:
 protected:
   void DisposeLocalMinimaList();
   TEdge* AddBoundsToLML(TEdge *e, bool IsClosed);
-  void PopLocalMinima();
   virtual void Reset();
   TEdge* ProcessBound(TEdge* E, bool IsClockwise);
-  void DoMinimaLML(TEdge* E1, TEdge* E2, bool IsClosed);
-  TEdge* DescendToMin(TEdge *&E);
-  void AscendToMax(TEdge *&E, bool Appending, bool IsClosed);
+  void InsertScanbeam(const cInt Y);
+  bool PopScanbeam(cInt &Y);
+  bool LocalMinimaPending();
+  bool PopLocalMinima(cInt Y, const LocalMinimum *&locMin);
+  OutRec* CreateOutRec();
+  void DisposeAllOutRecs();
+  void DisposeOutRec(PolyOutList::size_type index);
+  void SwapPositionsInAEL(TEdge *edge1, TEdge *edge2);
+  void DeleteFromAEL(TEdge *e);
+  void UpdateEdgeIntoAEL(TEdge *&e);
 
   typedef std::vector<LocalMinimum> MinimaList;
   MinimaList::iterator m_CurrentLM;
@@ -242,8 +250,13 @@ protected:
 
   bool              m_UseFullRange;
   EdgeList          m_edges;
-  bool             m_PreserveCollinear;
-  bool             m_HasOpenPaths;
+  bool              m_PreserveCollinear;
+  bool              m_HasOpenPaths;
+  PolyOutList       m_PolyOuts;
+  TEdge           *m_ActiveEdges;
+
+  typedef std::priority_queue<cInt> ScanbeamList;
+  ScanbeamList     m_Scanbeam;
 };
 //------------------------------------------------------------------------------
 
@@ -251,16 +264,21 @@ class Clipper : public virtual ClipperBase
 {
 public:
   Clipper(int initOptions = 0);
-  ~Clipper();
   bool Execute(ClipType clipType,
-    Paths &solution,
-    PolyFillType subjFillType = pftEvenOdd,
-    PolyFillType clipFillType = pftEvenOdd);
+      Paths &solution,
+      PolyFillType fillType = pftEvenOdd);
   bool Execute(ClipType clipType,
-    PolyTree &polytree,
-    PolyFillType subjFillType = pftEvenOdd,
-    PolyFillType clipFillType = pftEvenOdd);
-  bool ReverseSolution() {return m_ReverseOutput;};
+      Paths &solution,
+      PolyFillType subjFillType,
+      PolyFillType clipFillType);
+  bool Execute(ClipType clipType,
+      PolyTree &polytree,
+      PolyFillType fillType = pftEvenOdd);
+  bool Execute(ClipType clipType,
+      PolyTree &polytree,
+      PolyFillType subjFillType,
+      PolyFillType clipFillType);
+  bool ReverseSolution() { return m_ReverseOutput; };
   void ReverseSolution(bool value) {m_ReverseOutput = value;};
   bool StrictlySimple() {return m_StrictSimple;};
   void StrictlySimple(bool value) {m_StrictSimple = value;};
@@ -269,17 +287,14 @@ public:
   void ZFillFunction(ZFillCallback zFillFunc);
 #endif
 protected:
-  void Reset();
   virtual bool ExecuteInternal();
 private:
-  PolyOutList       m_PolyOuts;
-  JoinList          m_Joins;
-  JoinList          m_GhostJoins;
-  IntersectList     m_IntersectList;
-  ClipType          m_ClipType;
-  typedef std::priority_queue<cInt> ScanbeamList;
-  ScanbeamList      m_Scanbeam;
-  TEdge           *m_ActiveEdges;
+  JoinList         m_Joins;
+  JoinList         m_GhostJoins;
+  IntersectList    m_IntersectList;
+  ClipType         m_ClipType;
+  typedef std::list<cInt> MaximaList;
+  MaximaList       m_Maxima;
   TEdge           *m_SortedEdges;
   bool             m_ExecuteLocked;
   PolyFillType     m_ClipFillType;
@@ -293,31 +308,25 @@ private:
   void SetWindingCount(TEdge& edge);
   bool IsEvenOddFillType(const TEdge& edge) const;
   bool IsEvenOddAltFillType(const TEdge& edge) const;
-  void InsertScanbeam(const cInt Y);
-  cInt PopScanbeam();
   void InsertLocalMinimaIntoAEL(const cInt botY);
   void InsertEdgeIntoAEL(TEdge *edge, TEdge* startEdge);
   void AddEdgeToSEL(TEdge *edge);
+  bool PopEdgeFromSEL(TEdge *&edge);
   void CopyAELToSEL();
   void DeleteFromSEL(TEdge *e);
-  void DeleteFromAEL(TEdge *e);
-  void UpdateEdgeIntoAEL(TEdge *&e);
   void SwapPositionsInSEL(TEdge *edge1, TEdge *edge2);
   bool IsContributing(const TEdge& edge) const;
   bool IsTopHorz(const cInt XPos);
-  void SwapPositionsInAEL(TEdge *edge1, TEdge *edge2);
   void DoMaxima(TEdge *e);
-  void ProcessHorizontals(bool IsTopOfScanbeam);
-  void ProcessHorizontal(TEdge *horzEdge, bool isTopOfScanbeam);
+  void ProcessHorizontals();
+  void ProcessHorizontal(TEdge *horzEdge);
   void AddLocalMaxPoly(TEdge *e1, TEdge *e2, const IntPoint &pt);
   OutPt* AddLocalMinPoly(TEdge *e1, TEdge *e2, const IntPoint &pt);
   OutRec* GetOutRec(int idx);
   void AppendPolygon(TEdge *e1, TEdge *e2);
   void IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &pt);
-  OutRec* CreateOutRec();
   OutPt* AddOutPt(TEdge *e, const IntPoint &pt);
-  void DisposeAllOutRecs();
-  void DisposeOutRec(PolyOutList::size_type index);
+  OutPt* GetLastOutPt(TEdge *e);
   bool ProcessIntersections(const cInt topY);
   void BuildIntersectList(const cInt topY);
   void ProcessIntersectList();
@@ -328,6 +337,7 @@ private:
   void DisposeIntersectNodes();
   bool FixupIntersectionOrder();
   void FixupOutPolygon(OutRec &outrec);
+  void FixupOutPolyline(OutRec &outrec);
   bool IsHole(TEdge *e);
   bool FindOwnerFromSplitRecs(OutRec &outRec, OutRec *&currOrfl);
   void FixHoleLinkage(OutRec &outrec);
@@ -339,7 +349,8 @@ private:
   void JoinCommonEdges();
   void DoSimplePolygons();
   void FixupFirstLefts1(OutRec* OldOutRec, OutRec* NewOutRec);
-  void FixupFirstLefts2(OutRec* OldOutRec, OutRec* NewOutRec);
+  void FixupFirstLefts2(OutRec* InnerOutRec, OutRec* OuterOutRec);
+  void FixupFirstLefts3(OutRec* OldOutRec, OutRec* NewOutRec);
 #ifdef use_xyz
   void SetZ(IntPoint& pt, TEdge& e1, TEdge& e2);
 #endif

--- a/tests/test_pyclipper.py
+++ b/tests/test_pyclipper.py
@@ -246,8 +246,8 @@ class TestPyclipperExecute(TestCase):
 
     def test_clear(self):
         self.pc.Clear()
-        solution = self.pc.Execute(*self.default_args)
-        self.assertEqual(len(solution), 0)
+        with self.assertRaises(pyclipper.ClipperException):
+            solution = self.pc.Execute(*self.default_args)
 
     def test_exact_results(self):
         """


### PR DESCRIPTION
There were no changes in the ABI of the functions wrapped in pyclipper,
hence no major changes were performed here. Clipper.Execute now fails if
called after clear, and this brought changes to the test suite.

* Update embedded Clipper version
* Remove execution permissions from Clipper files
* Closes #10

sha256:
pyclipper/clipper.cpp:
5c642a3668311701f72572443aa42c1a981edb037298efc015166d9d90be0755
pyclipper/clipper.hpp:
734eba9dc9d399089b2b467017074bd24728a1b9e64c7429e827806ed10e54cc