### PR TITLE
use overloaded constructor instead of unsupported c++ default arguments

### DIFF
--- a/pyclipper/pyclipper.pyx
+++ b/pyclipper/pyclipper.pyx
@@ -166,7 +166,8 @@ cdef extern from "clipper.hpp" namespace "ClipperLib":
         cInt bottom
 
     cdef cppclass Clipper:
-        Clipper(int initOptions=0)
+        Clipper(int initOptions)
+        Clipper()
         #~Clipper()
         void Clear()
         bool Execute(ClipType clipType, Paths & solution, PolyFillType subjFillType, PolyFillType clipFillType)
@@ -182,7 +183,9 @@ cdef extern from "clipper.hpp" namespace "ClipperLib":
         IntRect GetBounds()
 
     cdef cppclass ClipperOffset:
-        ClipperOffset(double miterLimit = 2.0, double roundPrecision = 0.25)
+        ClipperOffset(double miterLimit, double roundPrecision)
+        ClipperOffset(double miterLimit)
+        ClipperOffset()
         #~ClipperOffset()
         void AddPath(Path & path, JoinType joinType, EndType endType)
         void AddPaths(Paths & paths, JoinType joinType, EndType endType)
@@ -742,9 +745,7 @@ cdef class PyclipperOffset:
         More info: http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/ClipperOffset/Methods/Constructor.htm
         """
         log_action("Creating an ClipperOffset instance")
-        self.thisptr = new ClipperOffset()
-        self.MiterLimit = miter_limit
-        self.ArcTolerance = arc_tolerance
+        self.thisptr = new ClipperOffset(miter_limit, arc_tolerance)
 
     def __dealloc__(self):
         log_action("Deleting the ClipperOffset instance")


### PR DESCRIPTION
quoting from https://groups.google.com/forum/#!topic/cython-users/4ecKM-p8dPA

> Default parameters for C++ methods are not yet supported (and it's an even worse bug that we don't give a sensible error message). For the time being you'll have to enumerate them as overloads.

related cython issue: https://github.com/cython/cython/issues/1374

After applying this patch, these warnings are no longer produced:

```
pyclipper/pyclipper.cpp:4307:55: warning: passing NULL to non-pointer argument 1 of ‘ClipperLib::Clipper::Clipper(int)’ [-Wconversion-null]
   __pyx_v_self->thisptr = new ClipperLib::Clipper(NULL);
                                                       ^
pyclipper/pyclipper.cpp: In function ‘int __pyx_pf_9pyclipper_15PyclipperOffset___cinit__(__pyx_obj_9pyclipper_PyclipperOffset*, double, double)’:
pyclipper/pyclipper.cpp:5895:61: warning: passing NULL to non-pointer argument 1 of ‘ClipperLib::ClipperOffset::ClipperOffset(double, double)’ [-Wconversion-null]
   __pyx_v_self->thisptr = new ClipperLib::ClipperOffset(NULL);
```