### PR TITLE
tests: catch ClipperException when calling Execute before any AddPath

### DIFF
--- a/tests/test_pyclipper.py
+++ b/tests/test_pyclipper.py
@@ -244,6 +244,13 @@ class TestPyclipperExecute(TestCase):
         self.assertIsInstance(solution, pyclipper.PyPolyNode)
         self.check_pypolynode(solution)
 
+    def test_execute_empty(self):
+        pc = pyclipper.Pyclipper()
+        with self.assertRaises(pyclipper.ClipperException):
+            pc.Execute(pyclipper.CT_UNION,
+                       pyclipper.PFT_NONZERO,
+                       pyclipper.PFT_NONZERO)
+
     def test_clear(self):
         self.pc.Clear()
         with self.assertRaises(pyclipper.ClipperException):


### PR DESCRIPTION
Calling `Execute` on an empty `Pyclipper` instance would silently pass without exception in previous pyclipper 1.0.7 with Clipper lib version 6.2.1.
Now, the `Clipper::Execute` method returns unsuccessful if called before any `AddPath`
or `AddPaths`, so pyclipper duly raises an exception.

Client code may need to be adjusted accordingly.